### PR TITLE
Remove build_docs from Actions workflow

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -40,9 +40,6 @@ jobs:
             tox_env: 'codestyle'
           - os: ubuntu-latest
             python: '3.10'
-            tox_env: 'build_docs'
-          - os: ubuntu-latest
-            python: '3.10'
             tox_env: 'linkcheck'
           - os: ubuntu-latest
             python: '3.10'
@@ -67,9 +64,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
-    - name: Install graphviz dependency
-      if: "endsWith(matrix.tox_env, 'build_docs')"
-      run: sudo apt-get -y install graphviz
     - name: Print Python, pip, setuptools, and tox versions
       run: |
         python -c "import sys; print(f'Python {sys.version}')"


### PR DESCRIPTION
RTD is now configured to build on PRs.