### PR TITLE
Remove pytest filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ xfail_strict = true
 remote_data_strict = true
 filterwarnings = [
     'error',  # turn warnings into exceptions
-    'ignore:numpy.ufunc size changed:RuntimeWarning',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
 ]
 


### PR DESCRIPTION
These ignored warnings no longer appear to be necessary.