### PR TITLE
Update min versions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,21 +31,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.11'
+            tox_env: 'py311-test-oldestdeps'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test-alldeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test-alldeps-cov'
-            toxposargs: --remote-data=any
             allow_failure: false
             prefix: ''
 
@@ -69,43 +62,61 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.12'
-            tox_env: 'py312-test'
+            tox_env: 'py312-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: macos-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: macos-14
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: 'M1'
+
+          - os: windows-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'linkcheck'
+            python: '3.13'
+            tox_env: 'py313-test-alldeps-cov'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.13'
             tox_env: 'codestyle'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.13'
+            tox_env: 'linkcheck'
+            allow_failure: false
+            prefix: ''
+
+          - os: ubuntu-latest
+            python: '3.13'
             tox_env: 'pep517'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.13'
             tox_env: 'bandit'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-oldestdeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test-devdeps'
+            python: '3.13'
+            tox_env: 'py313-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.11"
+    python: "3.13"
   jobs:
     post_checkout:
       - git fetch --shallow-since=2022-04-01 || true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,15 +7,13 @@ General
 - The ``lacosmic.test`` function has been removed. Instead use the
   ``pytest --pyarg lacosmic`` command. [#25]
 
-- The minimum required Python version is 3.10. [#26]
+- The minimum required Python version is 3.11. [#26, #47]
 
-- The minimum required Numpy version is 1.24. [#26]
+- The minimum required Numpy version is 1.26. [#26, #47]
 
-- The minimum required Scipy version is 1.10. [#26]
+- The minimum required Scipy version is 1.12. [#26, #47]
 
-- The minimum required Matplotlib version is 3.6. [#26]
-
-- The minimum required Astropy version is 5.1. [#26]
+- The minimum required Astropy version is 5.3. [#26, #47]
 
 
 1.1.0 (2023-11-16)

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2024, Larry Bradley
+Copyright (c) 2014-2025, Larry Bradley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,16 +15,12 @@ See astropy.sphinx.conf for which values are set there.
 
 import os
 import sys
-from datetime import datetime, timezone
+import tomllib
+from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 
 from sphinx.util import logging
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +34,7 @@ except ImportError:
 
 # Get configuration information from pyproject.toml
 with (Path(__file__).parents[1] / 'pyproject.toml').open('rb') as fh:
-    conf = tomllib.load(fh)
-    project_meta = conf['project']
+    project_meta = tomllib.load(fh)['project']
 
 # -- General configuration ----------------------------------------------------
 # By default, highlight as Python 3.
@@ -71,7 +66,7 @@ rst_epilog = """
 # -- Project information ------------------------------------------------------
 project = project_meta['name']
 author = project_meta['authors'][0]['name']
-project_copyright = f'2014-{datetime.now(tz=timezone.utc).year}, {author}'
+project_copyright = f'2014-{datetime.now(tz=UTC).year}, {author}'
 github_project = 'larrybradley/lacosmic'
 
 # The version info for the project you're documenting, acts as

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,13 +15,13 @@ Requirements
 
 ``lacosmic`` has the following requirements:
 
-* `Python <https://www.python.org/>`_ 3.10 or later
+* `Python <https://www.python.org/>`_ 3.11 or later
 
-* `NumPy <https://numpy.org/>`_ 1.24 or later
+* `NumPy <https://numpy.org/>`_ 1.26 or later
 
-* `Scipy <https://scipy.org/>`_ 1.10 or later
+* `SciPy <https://scipy.org/>`_ 1.12 or later
 
-* `Astropy`_ 5.1 or later
+* `Astropy`_ 5.3 or later
 
 
 Installation

--- a/lacosmic/conftest.py
+++ b/lacosmic/conftest.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
         # list of packages for which version numbers are displayed when
         # running the tests.
         PYTEST_HEADER_MODULES.clear()
-        deps = ['NumPy', 'SciPy', 'Matplotlib', 'Astropy']
+        deps = ['NumPy', 'SciPy', 'Astropy']
         for dep in deps:
             PYTEST_HEADER_MODULES[dep] = dep.lower()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 dependencies = [
-    'numpy>=1.24',
-    'astropy>=5.1',
-    'scipy>=1.10',
+    'numpy >= 1.26',
+    'astropy >= 5.3',
+    'scipy >= 1.12.0',
 ]
 
 [project.urls]
@@ -35,24 +35,26 @@ Homepage = 'https://github.com/larrybradley/lacosmic'
 Documentation = 'https://lacosmic.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
-all = [
-    'matplotlib>=3.6',
-]
 test = [
-    'pytest-astropy>=0.11',
+    'pytest-astropy >= 0.11',
+    'tox > 4.0',
 ]
 docs = [
-    'lacosmic[all]',
+    'lacosmic',
     'sphinx',
-    'sphinx-astropy>=1.9',
-    'tomli; python_version < "3.11"',
+    'sphinx-astropy >= 1.9',
+    'matplotlib >= 3.8',
+]
+dev = [
+   'lacosmic[docs,test]',
+   'pre-commit > 4.0',
 ]
 
 [build-system]
 requires = [
-    'setuptools>=61.2',
-    'setuptools_scm>=6.2',
-    'numpy>=2.0.0',
+    'setuptools >= 77.0',
+    'setuptools_scm >= 8.0',
+    'numpy >= 2.0.0',
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,17 +42,14 @@ description =
 deps =
     cov: pytest-cov
 
-    oldestdeps: numpy==1.24
-    oldestdeps: scipy==1.10
-    oldestdeps: matplotlib==3.6
-    oldestdeps: astropy==5.1
+    oldestdeps: minimum_dependencies
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
 
-    # Latest developer version of infrastructure packages.
+    # Latest developer version of infrastructure packages
     devinfra: git+https://github.com/pytest-dev/pytest.git
     devinfra: git+https://github.com/astropy/extension-helpers.git
     devinfra: git+https://github.com/astropy/pytest-doctestplus.git
@@ -69,10 +66,15 @@ extras =
     alldeps: all
     build_docs: docs
 
+install_command =
+    !devdeps: python -I -m pip install
+    devdeps: python -I -m pip install -v --pre
+
+commands_pre =
+    oldestdeps: minimum_dependencies lacosmic --filename requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
+
 commands =
-    # Force numpy-dev after matplotlib downgrades it
-    # (https://github.com/matplotlib/matplotlib/issues/26847)
-    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     pytest --pyargs lacosmic {toxinidir}/docs \
     cov: --cov lacosmic --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,18 @@
 [tox]
 envlist =
-    py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312}-test-numpy{124,125,126,200}
+    py{311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
     build_docs
     linkcheck
     codestyle
     pep517
     bandit
-requires =
-    setuptools >= 61.2
-    pip >= 19.3.1
 isolated_build = true
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
 
 # Pass through the following environment variables which may be needed
 # for the CI
@@ -41,18 +37,10 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy124: with numpy 1.24.*
-    numpy125: with numpy 1.25.*
-    numpy126: with numpy 1.26.*
 
 # The following provides some specific pinnings for key packages
 deps =
     cov: pytest-cov
-
-    numpy124: numpy==1.24.*
-    numpy125: numpy==1.25.*
-    numpy126: numpy==1.26.*
-    numpy200: numpy==2.0.*
 
     oldestdeps: numpy==1.24
     oldestdeps: scipy==1.10
@@ -61,8 +49,8 @@ deps =
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
-    devdeps: matplotlib>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+    devdeps: pyerfa>=0.0.dev0
 
     # Latest developer version of infrastructure packages.
     devinfra: git+https://github.com/pytest-dev/pytest.git


### PR DESCRIPTION
Following SPEC-0:

Python >= 3.11
NumPy >= 1.26
SciPy >= 1.12
Astropy >= 5.3
Matplotlib >= 3.8 (for docs only)